### PR TITLE
ad hoc rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "policy-metadata-helper"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "serde",
+ "serde_yaml",
+ "versions",
+]
+
+[[package]]
 name = "policy-version-helper"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [workspace]
 members = [
   "crates/versions",
+  "crates/policy-metadata-helper",
   "crates/policy-version-helper",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ e2e-tests: annotated-policy.wasm
 	bats e2e.bats
 
 .PHONY: test
-test: check-policy-version fmt lint
+test: check-policy-metadata check-policy-version fmt lint
 	cargo test --workspace
 
 .PHONY: expected-policy-version
@@ -31,9 +31,18 @@ expected-policy-version:
 check-policy-version:
 	cargo run --quiet --manifest-path crates/policy-version-helper/Cargo.toml -- --manifest-path Cargo.toml check
 
+.PHONY: expected-policy-metadata
+expected-policy-metadata:
+	cargo run --quiet --manifest-path crates/policy-metadata-helper/Cargo.toml -- --metadata-path metadata.yml build
+
+.PHONY: check-policy-metadata
+check-policy-metadata:
+	cargo run --quiet --manifest-path crates/policy-metadata-helper/Cargo.toml -- --metadata-path metadata.yml check
+
 .PHONY: clean
 clean:
 	cargo clean
 	cargo clean --manifest-path crates/policy-version-helper/Cargo.toml
+	cargo clean --manifest-path crates/policy-metadata-helper/Cargo.toml
 	cargo clean --manifest-path crates/versions/Cargo.toml
 	rm -f policy.wasm annotated-policy.wasm

--- a/crates/policy-metadata-helper/.gitignore
+++ b/crates/policy-metadata-helper/.gitignore
@@ -1,0 +1,9 @@
+/target
+*.wasm
+
+
+# Added by cargo
+#
+# already existing elements were commented out
+
+#/target

--- a/crates/policy-metadata-helper/Cargo.toml
+++ b/crates/policy-metadata-helper/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "policy-metadata-helper"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.9"
+versions = { path = "../versions" }

--- a/crates/policy-metadata-helper/src/cli.rs
+++ b/crates/policy-metadata-helper/src/cli.rs
@@ -1,0 +1,27 @@
+use clap::{Parser, Subcommand};
+
+/// Find the most recent Kubernetes version mentioned inside of `versions.yml`
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub(crate) struct Cli {
+    /// Path to the metadata.yml of the policy
+    #[arg(short, long)]
+    pub metadata_path: String,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+impl Cli {
+    pub(crate) fn new() -> Self {
+        Self::parse()
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Propose the rules to be used inside of the policy metadata
+    Build {},
+    /// Check if the rules defined inside of the metadata are correct
+    Check {},
+}

--- a/crates/policy-metadata-helper/src/main.rs
+++ b/crates/policy-metadata-helper/src/main.rs
@@ -1,0 +1,81 @@
+use std::collections::{HashMap, HashSet};
+use versions::Versions;
+
+mod cli;
+mod policy_metadata;
+use policy_metadata::{MetadataLite as PolicyMetadata, Operation, Rule as PolicyMetadataRule};
+
+const K8S_COMPONENT: &str = "k8s";
+
+fn generate_metadata_rules() -> Vec<PolicyMetadataRule> {
+    let mut metadata_rules: Vec<PolicyMetadataRule> = vec![];
+
+    let mut relevant_versions: HashMap<String, HashSet<String>> = HashMap::new();
+
+    let versions: Versions = serde_yaml::from_slice(include_bytes!("../../../versions.yaml"))
+        .expect("Cannot decode versions.yml");
+
+    for rule in &versions.deprecated_versions {
+        if rule.component != K8S_COMPONENT {
+            continue;
+        }
+        let buffer: Vec<&str> = rule.version.splitn(2, '/').collect();
+        let (api_group, api_version) = if buffer.len() != 2 {
+            ("", buffer[0])
+        } else {
+            (buffer[0], buffer[1])
+        };
+
+        let mut api_versions: HashSet<String> = if relevant_versions.contains_key(api_group) {
+            relevant_versions[api_group].clone()
+        } else {
+            HashSet::new()
+        };
+        api_versions.insert(api_version.to_string());
+        relevant_versions.insert(api_group.to_string(), api_versions);
+    }
+
+    let mut api_groups: Vec<String> = relevant_versions.keys().map(|k| k.to_string()).collect();
+    api_groups.sort();
+
+    for api_group in &api_groups {
+        let mut api_versions: Vec<String> = relevant_versions[api_group].iter().cloned().collect();
+        api_versions.sort();
+
+        metadata_rules.push(PolicyMetadataRule {
+            api_groups: vec![api_group.to_owned()],
+            api_versions,
+            resources: vec!["*".to_string()],
+            operations: vec![Operation::Create],
+        });
+    }
+
+    metadata_rules
+}
+
+pub fn main() {
+    let cli = cli::Cli::new();
+    if cli.metadata_path.is_empty() {
+        eprintln!("You must provide the path to the metadata.yml file of the policy");
+        std::process::exit(1);
+    }
+
+    let metadata_raw = std::fs::read(cli.metadata_path).expect("Error reading metadata file");
+    let metadata: PolicyMetadata =
+        serde_yaml::from_slice(&metadata_raw).expect("Cannot deserialize PolicyMetadata");
+
+    let expected_rules = generate_metadata_rules();
+
+    match &cli.command {
+        Some(cli::Commands::Build {}) => {
+            println!("{}", serde_yaml::to_string(&expected_rules).unwrap());
+        }
+        Some(cli::Commands::Check {}) => {
+            if metadata.rules != expected_rules {
+                eprintln!("Current rules are not correct.");
+                std::process::exit(1);
+            }
+        }
+        None => {}
+    };
+}

--- a/crates/policy-metadata-helper/src/policy_metadata.rs
+++ b/crates/policy-metadata-helper/src/policy_metadata.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+// This is a stripped down copy of `policy_evaluator::policy_metadata`
+// We could introduce policy_evaluator as a dependency, but that would
+// cause the whole wapc environment to be built for this tiny cli program :/
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataLite {
+    pub rules: Vec<Rule>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
+pub enum Operation {
+    #[serde(rename = "CREATE")]
+    Create,
+    #[serde(rename = "UPDATE")]
+    Update,
+    #[serde(rename = "DELETE")]
+    Delete,
+    #[serde(rename = "CONNECT")]
+    Connect,
+    #[serde(rename = "*")]
+    All,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Rule {
+    pub api_groups: Vec<String>,
+    pub api_versions: Vec<String>,
+    pub resources: Vec<String>,
+    pub operations: Vec<Operation>,
+}

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,8 +1,152 @@
 rules:
-- apiGroups: ["*"]
-  apiVersions: ["*"]
-  resources: ["*"]
-  operations: ["CREATE"]
+- apiGroups:
+  - admissionregistration.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - apiextensions.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - apiregistration.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - apps
+  apiVersions:
+  - v1beta1
+  - v1beta2
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - authentication.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - autoscaling
+  apiVersions:
+  - v2beta1
+  - v2beta2
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - batch
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - certificates.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - coordination.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - discovery.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - events.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - extensions
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - networking.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - policy
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - rbac.authorization.k8s.io
+  apiVersions:
+  - v1alpha1
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - scheduling.k8s.io
+  apiVersions:
+  - v1alpha1
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
+- apiGroups:
+  - storage.k8s.io
+  apiVersions:
+  - v1beta1
+  resources:
+  - '*'
+  operations:
+  - CREATE
 mutating: false
 contextAware: false
 executionMode: kubewarden-wapc


### PR DESCRIPTION
Prior to this PR the policy was targeting all types of Kubernetes resources via the `*` selector.
This is not needed, because the policy knows exactly what kind of resources have been deprecated, hence it can listen only for events related to these resource types.

Why we needed to change this behaviour:

* Reduce the load on the policy server: listen only for relevant events
* Make it easy for the audit scan to inspect this policy

Fixes https://github.com/kubewarden/deprecated-api-versions-policy/issues/4