### PR TITLE
Bump v0.1.10-k8sv1.29.0 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "deprecated-api-versions"
-version = "0.1.9-k8sv1.29.0"
+version = "0.1.10-k8sv1.29.0"
 dependencies = [
  "anyhow",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deprecated-api-versions"
-version = "0.1.9-k8sv1.29.0"
+version = "0.1.10-k8sv1.29.0"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2021"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,28 +4,28 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.9-k8sv1.29.0
+version: 0.1.10-k8sv1.29.0
 name: deprecated-api-versions
 displayName: Deprecated API Versions
-createdAt: 2023-06-28T07:49:24.424186039Z
+createdAt: 2023-07-10T16:27:53.95192879Z
 description: Find deprecated and removed Kubernetes resources
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/deprecated-api-versions
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.9-k8sv1.29.0
+  image: ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.10-k8sv1.29.0
 keywords:
 - compliance
 - deprecated API
 links:
 - name: policy
-  url: https://github.com/kubewarden/deprecated-api-versions/releases/download/v0.1.9-k8sv1.29.0/policy.wasm
+  url: https://github.com/kubewarden/deprecated-api-versions/releases/download/v0.1.10-k8sv1.29.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/deprecated-api-versions
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.9-k8sv1.29.0
+  kwctl pull ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.10-k8sv1.29.0
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.10-k8sv1.29.0 policy version.        

Updates files bumping the policy version to v0.1.10-k8sv1.29.0

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
