### PR TITLE
fix repo URL in metadata.yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "deprecated-api-versions"
-version = "0.1.10-k8sv1.29.0"
+version = "0.1.11-k8sv1.29.0"
 dependencies = [
  "anyhow",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deprecated-api-versions"
-version = "0.1.10-k8sv1.29.0"
+version = "0.1.11-k8sv1.29.0"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2021"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -7,10 +7,10 @@
 version: 0.1.10-k8sv1.29.0
 name: deprecated-api-versions
 displayName: Deprecated API Versions
-createdAt: 2023-07-10T16:27:53.95192879Z
+createdAt: 2023-07-14T15:15:39.337441641Z
 description: Find deprecated and removed Kubernetes resources
 license: Apache-2.0
-homeURL: https://github.com/kubewarden/deprecated-api-versions
+homeURL: https://github.com/kubewarden/deprecated-api-versions-policy
 containersImages:
 - name: policy
   image: ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.10-k8sv1.29.0
@@ -19,9 +19,9 @@ keywords:
 - deprecated API
 links:
 - name: policy
-  url: https://github.com/kubewarden/deprecated-api-versions/releases/download/v0.1.10-k8sv1.29.0/policy.wasm
+  url: https://github.com/kubewarden/deprecated-api-versions-policy/releases/download/v0.1.10-k8sv1.29.0/policy.wasm
 - name: source
-  url: https://github.com/kubewarden/deprecated-api-versions
+  url: https://github.com/kubewarden/deprecated-api-versions-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,28 +4,28 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.10-k8sv1.29.0
+version: 0.1.11-k8sv1.29.0
 name: deprecated-api-versions
 displayName: Deprecated API Versions
-createdAt: 2023-07-14T15:15:39.337441641Z
+createdAt: 2023-07-17T13:51:08.327238576Z
 description: Find deprecated and removed Kubernetes resources
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/deprecated-api-versions-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.10-k8sv1.29.0
+  image: ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.11-k8sv1.29.0
 keywords:
 - compliance
 - deprecated API
 links:
 - name: policy
-  url: https://github.com/kubewarden/deprecated-api-versions-policy/releases/download/v0.1.10-k8sv1.29.0/policy.wasm
+  url: https://github.com/kubewarden/deprecated-api-versions-policy/releases/download/v0.1.11-k8sv1.29.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/deprecated-api-versions-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.10-k8sv1.29.0
+  kwctl pull ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.11-k8sv1.29.0
   ```
 maintainers:
 - name: Kubewarden developers

--- a/metadata.yml
+++ b/metadata.yml
@@ -170,8 +170,8 @@ annotations:
   io.kubewarden.policy.title: deprecated-api-versions
   io.kubewarden.policy.description: Find deprecated and removed Kubernetes resources
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
-  io.kubewarden.policy.url: https://github.com/kubewarden/deprecated-api-versions
-  io.kubewarden.policy.source: https://github.com/kubewarden/deprecated-api-versions
+  io.kubewarden.policy.url: https://github.com/kubewarden/deprecated-api-versions-policy
+  io.kubewarden.policy.source: https://github.com/kubewarden/deprecated-api-versions-policy
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.category: Kubernetes API Versions
   io.kubewarden.policy.severity: low


### PR DESCRIPTION
## Description

Realized on artifacthub.io that the policy is pointing to the wrong URL.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
