### PR TITLE
Bump for release 0.1.13-k8sv1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "deprecated-api-versions"
-version = "0.1.12-k8sv1.29.0"
+version = "0.1.13-k8sv1.30.0"
 dependencies = [
  "anyhow",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deprecated-api-versions"
-version = "0.1.12-k8sv1.29.0"
+version = "0.1.13-k8sv1.30.0"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2021"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,32 +4,32 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.12-k8sv1.29.0
+version: 0.1.13-k8sv1.30.0
 name: deprecated-api-versions
 displayName: Deprecated API Versions
-createdAt: 2023-12-19T10:47:34.775523708Z
+createdAt: 2024-07-03T15:00:40.483049707Z
 description: Find deprecated and removed Kubernetes resources
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/deprecated-api-versions-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.12-k8sv1.29.0
+  image: ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.13-k8sv1.30.0
 keywords:
 - compliance
 - deprecated API
 links:
 - name: policy
-  url: https://github.com/kubewarden/deprecated-api-versions-policy/releases/download/v0.1.12-k8sv1.29.0/policy.wasm
+  url: https://github.com/kubewarden/deprecated-api-versions-policy/releases/download/v0.1.13-k8sv1.30.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/deprecated-api-versions-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.12-k8sv1.29.0
+  kwctl pull ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.13-k8sv1.30.0
   ```
   Then, generate the policy manifest and tune it to your liking. For example:
   ```console
-  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.12-k8sv1.29.0
+  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/deprecated-api-versions:v0.1.13-k8sv1.30.0
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/kubewarden-controller/issues/794.


This prepares for tagging 0.1.13-k8sv1.13.0.

Bump of the patch release is needed for artifacthub to recognize the release.

No need for bumps on versions.yaml, the GHA jobs say it's already updated (see [here](https://github.com/kubewarden/deprecated-api-versions-policy/actions/workflows/check-versions-updates-cron.yml)).

Hence this release just signifies that the policy is up-to-date with k8s 1.30.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
