### PR TITLE
fix: ci check policy metadata and runs-on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
 
   check-metadata:
-    runs-on: ubuntu
+    runs-on: ubuntu-latest
     steps:
       - id: check-policy-metadata
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
   release:
     needs:
       - test
-      - check-metadata
+      - check-policy-metadata
     permissions:
       # Required to create GH releases
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   check-metadata:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - id: check-policy-metadata
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
   check-metadata:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - id: check-policy-metadata
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
 
   check-metadata:
-    runs-on: ubuntu
+    runs-on: ubuntu-latest
     steps:
       - id: check-policy-metadata
         shell: bash


### PR DESCRIPTION
## Description

Fixes:
- wrong `runs-on` image name.
- wrong id in the `needs` directive of the release job
- no checkout before running `check-policy-metadata` make target
