### PR TITLE
fix: check policy metadata job name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
 
-  check-metadata:
+  check-policy-metadata:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Description

Fixes the check policy metadata job name to match the `needs` directive of the release job.