### PR TITLE
ci: Pin digests of github-actions via renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
       "description": "Update GitHub Actions",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
-      "groupSlug": "github-actions"
+      "groupSlug": "github-actions",
+      "pinDigests": true
     }
   ]
 }


### PR DESCRIPTION
We need to be explicit about `pinDigest`, since we are overloading the `extends` that we provide.

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/kubewarden-controller/issues/1108

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
